### PR TITLE
Add Rise Vision Custom Auth support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.iml
 eclipse-launch-profiles
 target
+.classpath
+.project
+.settings/

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ dependencies:
   pre:
     - mkdir -p src/private-keys
     - git clone git@github.com:Rise-Vision/private-keys.git
+    - cp private-keys/core/.appcfg_oauth2_tokens_java ~
     - cp private-keys/monitoring-service/* src/private-keys
   cache_directories:
     - /home/ubuntu/nvm
@@ -17,11 +18,11 @@ deployment:
   staging:
     branch: /(feature|hotfix|fix|chore).*/
     commands:
-      - mvn appengine:update -s config/settings.xml -Pstage -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvacore-test <<< $JENKINS_PASS
+      - mvn appengine:update -s config/settings.xml -Pstage -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvacore-test
   #      - mvn appengine:set_default_version -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvacore-test <<< $JENKINS_PASS
   production:
     branch: master
     commands:
       - mvn clean
-      - mvn appengine:update -s config/settings.xml -Pprod -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%10))) -Dappengine.appId=rvaserver2 <<< $JENKINS_PASS
-      - mvn appengine:set_default_version -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%10))) -Dappengine.appId=rvaserver2 <<< $JENKINS_PASS
+      - mvn appengine:update -s config/settings.xml -Pprod -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%10))) -Dappengine.appId=rvaserver2
+      - mvn appengine:set_default_version -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%10))) -DskipTests -Dappengine.appId=rvaserver2

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 dependencies:
+  override:
+    - mvn dependency:resolve -s config/settings.xml
   pre:
     - mkdir -p src/private-keys
     - git clone git@github.com:Rise-Vision/private-keys.git
@@ -7,19 +9,19 @@ dependencies:
     - /home/ubuntu/nvm
   post:
     - if [[ ! -e src/private-keys/rvaserver2-b9c4159f9ef9.p12 ]]; then exit 1; fi
-    - mvn install
-    - pwd && mvn appengine:devserver_start:
+    - mvn -s config/settings.xml install
+    - pwd && mvn -s config/settings.xml appengine:devserver_start:
         background: true
 
 deployment:
   staging:
     branch: /(feature|hotfix|fix|chore).*/
     commands:
-      - mvn appengine:update -Pstage -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvacore-test <<< $JENKINS_PASS
+      - mvn appengine:update -s config/settings.xml -Pstage -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvacore-test <<< $JENKINS_PASS
   #      - mvn appengine:set_default_version -Dappengine.version=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}') -Dappengine.appId=rvacore-test <<< $JENKINS_PASS
   production:
     branch: master
     commands:
-      - mvn clean install -Pprod
-      - mvn appengine:update -Pprod -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%10))) -Dappengine.appId=rvaserver2 <<< $JENKINS_PASS
+      - mvn clean
+      - mvn appengine:update -s config/settings.xml -Pprod -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%10))) -Dappengine.appId=rvaserver2 <<< $JENKINS_PASS
       - mvn appengine:set_default_version -Dappengine.version=r$(echo -n $((CIRCLE_BUILD_NUM%10))) -Dappengine.appId=rvaserver2 <<< $JENKINS_PASS

--- a/config/settings.xml
+++ b/config/settings.xml
@@ -1,0 +1,39 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository/>
+    <interactiveMode/>
+    <usePluginRegistry/>
+    <offline/>
+    <pluginGroups/>
+    <servers>
+        <server>
+            <id>mvn-repo-releases</id>
+            <configuration>
+                <httpHeaders>
+                    <property>
+                        <name>Authorization</name>
+                        <value>token ${env.GITHUB_TOKEN}</value>
+                    </property>
+                </httpHeaders>
+            </configuration>
+        </server>
+
+        <server>
+            <id>mvn-repo-snapshots</id>
+            <configuration>
+                <httpHeaders>
+                    <property>
+                        <name>Authorization</name>
+                        <value>token ${env.GITHUB_TOKEN}</value>
+                    </property>
+                </httpHeaders>
+            </configuration>
+        </server>
+    </servers>
+    <mirrors/>
+    <proxies/>
+    <profiles/>
+    <activeProfiles/>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
             <version>${appengine.target.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.risevision.common</groupId>
+            <artifactId>common-backend-components</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.risevision.common</groupId>
             <artifactId>common-backend-components</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>monitoring-service</artifactId>
 
     <properties>
-        <appengine.target.version>1.9.15</appengine.target.version>
+        <appengine.target.version>1.9.34</appengine.target.version>
         <appengine.app.version>1</appengine.app.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <google.client.version>1.19.1</google.client.version>
@@ -217,7 +217,7 @@
             <plugin>
                 <groupId>com.google.appengine</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>1.9.4</version>
+                <version>${appengine.target.version}</version>
                 <configuration>
                     <enableJarClasses>false</enableJarClasses>
                     <!-- Comment in the below snippet to bind to all IPs instead of just localhost -->

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,11 @@
                 <version>${appengine.target.version}</version>
                 <configuration>
                     <enableJarClasses>false</enableJarClasses>
+                    <port>8888</port>
+                    <email>jenkins@risevision.com</email>
+                    <oauth2>true</oauth2>
+                    <!-- <noCookies>true</noCookies> -->
+                    <!-- <passin>true</passin> -->
                     <!-- Comment in the below snippet to bind to all IPs instead of just localhost -->
                     <!-- address>0.0.0.0</address>
                     <port>8080</port -->
@@ -228,11 +233,6 @@
                     <!-- jvmFlags>
                       <jvmFlag>-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n</jvmFlag>
                     </jvmFlags -->
-                    <port>8888</port>
-                    <email>jenkins@risevision.com</email>
-                    <oauth2>false</oauth2>
-                    <noCookies>true</noCookies>
-                    <passin>true</passin>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,31 @@
         <maven>3.1.0</maven>
     </prerequisites>
 
+    <repositories>
+        <repository>
+            <id>mvn-repo-releases</id>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <name>Maven Repository - Releases</name>
+            <url>https://raw.github.com/Rise-Vision/mvn-repo/releases</url>
+        </repository>
+        <repository>
+            <id>mvn-repo-snapshots</id>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <name>Maven Repository - Snapshots</name>
+            <url>https://raw.github.com/Rise-Vision/mvn-repo/snapshots</url>
+        </repository>
+    </repositories>
+
     <profiles>
         <profile>
             <id>prod</id>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
             <artifactId>config</artifactId>
             <version>1.2.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.risevision.common</groupId>
+            <artifactId>common-backend-components</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
 
 
         <!-- Test Dependencies -->
@@ -154,11 +159,6 @@
             <artifactId>appengine-api-stubs</artifactId>
             <version>${appengine.target.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.risevision.common</groupId>
-            <artifactId>common-backend-components</artifactId>
-            <version>1.0.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/risevision/monitoring/service/api/MonitoringAPIv0.java
+++ b/src/main/java/com/risevision/monitoring/service/api/MonitoringAPIv0.java
@@ -1,6 +1,7 @@
 package com.risevision.monitoring.service.api;
 
 import com.google.api.server.spi.ServiceException;
+import com.google.api.server.spi.auth.EndpointsAuthenticator;
 import com.google.api.server.spi.config.Api;
 import com.google.api.server.spi.config.ApiMethod;
 import com.google.api.server.spi.config.ApiNamespace;
@@ -8,6 +9,7 @@ import com.google.api.server.spi.config.Named;
 import com.google.api.server.spi.response.BadRequestException;
 import com.google.api.server.spi.response.UnauthorizedException;
 import com.google.appengine.api.users.User;
+import com.risevision.common.security.customauth.UserAuthAuthenticator;
 import com.risevision.monitoring.service.api.accessors.AppActivityAccessor;
 import com.risevision.monitoring.service.api.resources.Resource;
 
@@ -21,7 +23,8 @@ import javax.xml.bind.ValidationException;
         namespace = @ApiNamespace(ownerDomain = "risevision.com",
                 ownerName = "risevision",
                 packagePath = "com/risevision/monitoring"),
-        clientIds = {"614513768474.apps.googleusercontent.com", com.google.api.server.spi.Constant.API_EXPLORER_CLIENT_ID}
+        clientIds = {"614513768474.apps.googleusercontent.com", com.google.api.server.spi.Constant.API_EXPLORER_CLIENT_ID},
+        authenticators = { UserAuthAuthenticator.class, EndpointsAuthenticator.class }
 )
 
 public class MonitoringAPIv0 {

--- a/src/main/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientService.java
+++ b/src/main/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientService.java
@@ -1,0 +1,6 @@
+package com.risevision.monitoring.service.services.oauth;
+
+public interface CustomAuthClientService {
+	public boolean isCustomAuthToken(String token);
+  public TokenInfo lookupTokenInfo(String token);
+}

--- a/src/main/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceImpl.java
+++ b/src/main/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceImpl.java
@@ -17,7 +17,7 @@ public class CustomAuthClientServiceImpl implements CustomAuthClientService {
 		TokenClaims claims = TokenManager.getInstance().getTokenClaims(token);
 		
 		if (claims.getStatus() == TokenStatus.VALID) {
-			tokenInfo = new TokenInfo("Rise Vision's Custom Auth", claims.getSubject());
+			tokenInfo = new TokenInfo("Rise Vision JWT", claims.getSubject());
 		}
 
 		return tokenInfo;

--- a/src/main/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceImpl.java
+++ b/src/main/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceImpl.java
@@ -1,0 +1,25 @@
+package com.risevision.monitoring.service.services.oauth;
+
+import com.risevision.common.security.customauth.TokenManager;
+import com.risevision.common.security.customauth.TokenManager.TokenClaims;
+import com.risevision.common.security.customauth.TokenManager.TokenStatus;
+
+public class CustomAuthClientServiceImpl implements CustomAuthClientService {
+
+	@Override
+	public boolean isCustomAuthToken(String token) {
+		return TokenManager.getInstance().isValidJWTFormat(token);
+	}
+
+	@Override
+	public TokenInfo lookupTokenInfo(String token) {
+		TokenInfo tokenInfo = null;
+		TokenClaims claims = TokenManager.getInstance().getTokenClaims(token);
+		
+		if (claims.getStatus() == TokenStatus.VALID) {
+			tokenInfo = new TokenInfo("Rise Vision's Custom Auth", claims.getSubject());
+		}
+
+		return tokenInfo;
+	}
+}

--- a/src/main/java/com/risevision/monitoring/service/services/oauth/TokenInfo.java
+++ b/src/main/java/com/risevision/monitoring/service/services/oauth/TokenInfo.java
@@ -14,6 +14,15 @@ public class TokenInfo {
     private Boolean verified_email;
     private String access_type;
 
+    public TokenInfo() {
+
+    }
+
+    public TokenInfo(String issued_to, String user_id) {
+      this.issued_to = issued_to;
+      this.user_id = user_id;
+    }
+
     public String getIssued_to() {
         return issued_to;
     }

--- a/src/main/java/com/risevision/monitoring/service/services/oauth/TokenInfo.java
+++ b/src/main/java/com/risevision/monitoring/service/services/oauth/TokenInfo.java
@@ -18,9 +18,9 @@ public class TokenInfo {
 
     }
 
-    public TokenInfo(String issued_to, String user_id) {
+    public TokenInfo(String issued_to, String email) {
       this.issued_to = issued_to;
-      this.user_id = user_id;
+      this.email = email;
     }
 
     public String getIssued_to() {

--- a/src/test/java/com/risevision/monitoring/service/queue/tasks/MonitoringLogTaskTest.java
+++ b/src/test/java/com/risevision/monitoring/service/queue/tasks/MonitoringLogTaskTest.java
@@ -1,23 +1,28 @@
 package com.risevision.monitoring.service.queue.tasks;
 
-import com.google.api.services.bigquery.model.TableRow;
-import com.risevision.monitoring.service.services.oauth.GoogleOAuthClientService;
-import com.risevision.monitoring.service.services.oauth.TokenInfo;
-import com.risevision.monitoring.service.services.storage.bigquery.BigQueryService;
-import com.risevision.monitoring.service.util.Options;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.io.IOException;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import com.google.api.services.bigquery.model.TableRow;
+import com.risevision.monitoring.service.services.oauth.CustomAuthClientService;
+import com.risevision.monitoring.service.services.oauth.GoogleOAuthClientService;
+import com.risevision.monitoring.service.services.oauth.TokenInfo;
+import com.risevision.monitoring.service.services.storage.bigquery.BigQueryService;
+import com.risevision.monitoring.service.util.Options;
 
 /**
  * Created by rodrigopavezi on 2/5/15.
@@ -30,6 +35,8 @@ public class MonitoringLogTaskTest {
     private Options options;
     @Mock
     private GoogleOAuthClientService googleOAuthClientService;
+    @Mock
+    private CustomAuthClientService customAuthClientService;
     @Mock
     private TokenInfo tokenInfo;
 
@@ -53,7 +60,7 @@ public class MonitoringLogTaskTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         row = new TableRow();
-        monitoringLogTask = new MonitoringLogTask(bigQueryService, options, googleOAuthClientService, row);
+        monitoringLogTask = new MonitoringLogTask(bigQueryService, options, googleOAuthClientService, customAuthClientService, row);
 
         ip = "1.1.1.1";
         host = "test.com";

--- a/src/test/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceTest.java
+++ b/src/test/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceTest.java
@@ -28,7 +28,7 @@ public class CustomAuthClientServiceTest {
         TokenInfo tokenInfo = customAuthClientService.lookupTokenInfo(token);
 
         assertNotNull(tokenInfo);
-        assertEquals(tokenInfo.getUser_id(), testEmail);
+        assertEquals(tokenInfo.getEmail(), testEmail);
     }
 
     @Test

--- a/src/test/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceTest.java
+++ b/src/test/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceTest.java
@@ -2,6 +2,7 @@ package com.risevision.monitoring.service.services.oauth;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 
@@ -28,5 +29,12 @@ public class CustomAuthClientServiceTest {
 
         assertNotNull(tokenInfo);
         assertEquals(tokenInfo.getUser_id(), testEmail);
+    }
+
+    @Test
+    public void testLookUpTokenInfoNotValid() throws IOException {
+        TokenInfo tokenInfo = customAuthClientService.lookupTokenInfo("a.b.c");
+
+        assertNull(tokenInfo);
     }
 }

--- a/src/test/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceTest.java
+++ b/src/test/java/com/risevision/monitoring/service/services/oauth/CustomAuthClientServiceTest.java
@@ -1,0 +1,32 @@
+package com.risevision.monitoring.service.services.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.risevision.common.security.customauth.TokenManager;
+
+public class CustomAuthClientServiceTest {
+
+    private CustomAuthClientService customAuthClientService;
+
+    @Before
+    public void setup() {
+        customAuthClientService = new CustomAuthClientServiceImpl();
+    }
+
+    @Test
+    public void testLookUpTokenInfoValidToken() throws IOException {
+    	  String testEmail = "test@mail.org";
+        String token = TokenManager.getInstance().generateToken(testEmail, 10000);
+
+        TokenInfo tokenInfo = customAuthClientService.lookupTokenInfo(token);
+
+        assertNotNull(tokenInfo);
+        assertEquals(tokenInfo.getUser_id(), testEmail);
+    }
+}


### PR DESCRIPTION
This PR originally was meant to add support for Custom Authentication (as done for Core, Store and Storage), but build updates and further changes (described below) were needed.
Monitoring Service receives a token (up until now, only a Google generated token) and gets information about it (mainly, userId and clientId). Since we now have a Custom Authentication mechanism, Monitoring Service was failing because it was not able to retrieve information about the user. The last few commits on this PR address that.

@alex-deaconu @alexey-rise @olegrise @rodrigopavezi please review
